### PR TITLE
Feature: add full text search index for projects

### DIFF
--- a/db/migrate/006_add_search_index_to_projects.rb
+++ b/db/migrate/006_add_search_index_to_projects.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Sequel.migration do
+  up do
+    run 'CREATE EXTENSION pg_trgm'
+    run 'CREATE INDEX projects_name_search_index ON projects USING gist (name gist_trgm_ops)'
+  end
+
+  down do
+    run 'DROP INDEX projects_name_search_index'
+    run 'DROP EXTENSION pg_trgm'
+  end
+end


### PR DESCRIPTION
Hello!

This commit adds full text search index for `projects` table (see https://github.com/ossert/ossert-web/issues/7)

Also there is `db:rollback` task. Originally it was used to check for migration reversibility. But after that I though that this feature may be convinient in future. 
What do you think?