### PR TITLE
Fix: make .random_top more predictable

### DIFF
--- a/lib/ossert/repositories.rb
+++ b/lib/ossert/repositories.rb
@@ -22,7 +22,9 @@ class Project < Sequel::Model
   set_primary_key [:name]
 
   def_dataset_method(:random) do |count|
-    where('github_name <> ? AND random() < ?', Ossert::NO_GITHUB_NAME, count * 0.05).limit(count)
+    where('github_name <> ?', Ossert::NO_GITHUB_NAME)
+      .order(Sequel.lit('random()'))
+      .limit(count)
   end
 
   class << self

--- a/spec/ossert_spec.rb
+++ b/spec/ossert_spec.rb
@@ -263,7 +263,7 @@ describe Ossert do
     it { expect { projectD.dump_attribute(:community_total_data) }.not_to raise_error }
     it { expect { projectD.dump_attribute(:agility_quarters_data) }.not_to raise_error }
     it { expect { projectD.dump_attribute(:community_quarters_data) }.not_to raise_error }
-    it { expect { Ossert::Project.random_top }.not_to raise_error }
+    it { expect(Ossert::Project.random_top.map(&:name)).to match_array([@a_project, @b_project, @c_project]) }
     it { expect { Ossert::Project.random }.not_to raise_error }
     it { expect(Ossert::Project.load_later_than(0)).not_to be_empty }
 


### PR DESCRIPTION
Fix `.random` to be more predictable: always returns records if they exists.